### PR TITLE
fix(API): s/eraseTransformation/abortTransformation/ (refs #4703)

### DIFF
--- a/Class/Class.TEClient.php
+++ b/Class/Class.TEClient.php
@@ -34,8 +34,6 @@ class Client
     const TASK_STATE_PROCESSING = 'P'; // Engine is running
     const TASK_STATE_WAITING = 'W'; // Job registered, waiting to start engine
     const TASK_STATE_INTERRUPTED = 'I'; // Job was interrupted
-    const TASK_STATE_SENT = 'S'; // Resulting file has been retrieved/sent
-
     const error_connect = - 2;
     const error_noengine = - 3;
     const error_sendfile = - 4;
@@ -290,8 +288,7 @@ class Client
      */
     function getTransformation($tid, $filename)
     {
-        $err = $this->getAndLeaveTransformation($tid, $filename);
-        $this->eraseTransformation($tid);
+        return $this->getAndLeaveTransformation($tid, $filename);
     }
     /**
      * send a request for retrieve a transformation
@@ -404,15 +401,14 @@ class Client
         return $err;
     }
     /**
-     * erase transformation
-     * delete associated files in the server engine
+     * Abort a transformation and delete associated files on the server
      * @param string $tid Task identification
      * @param string $filename the path where put the file (must be writeable)
      * @param array &$info transformation task info return "tid"=> ,"status"=> ,"comment=>
      *
      * @return string error message, if no error empty string
      */
-    function eraseTransformation($tid)
+    function abortTransformation($tid)
     {
         $err = "";
         /* Lit l'adresse IP du serveur de destination */

--- a/info.xml.in
+++ b/info.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf8"?>
 <module name="@PACKAGE@" version="@VERSION@" release="@RELEASE@" license="@LICENSE@">
   <requires>
-    <module name="dynacase-core" comp="ge" version="3.2.18"/>
+    <module name="dynacase-core" comp="ge" version="3.2.19"/>
     <module name="dynacase-admin" comp="ge" version="1.0.2"/>
   </requires>
   <post-install>


### PR DESCRIPTION
eraseTransformation() is renamed to abortTransformation().

Also:
- The state 'S' (sent) has been suppressed: when the result file is
  retrieved by the client, the task is now deleted and do not remains in
  state 'S'. The final tasks' states are now: 'I', 'D' or 'K'.